### PR TITLE
Scrape Headers from Urls

### DIFF
--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,21 +1,21 @@
 class Friendship < ApplicationRecord
     belongs_to :member
     belongs_to :friend, class_name: "Member"
-  
+
     after_create :create_inverse, unless: :has_inverse?
-  
+
     private
-  
+
     def create_inverse
       self.class.create(inverse_options)
     end
-  
+
     def has_inverse?
       self.class.exists?(inverse_options)
     end
-  
+
     def inverse_options
       { member_id: friend_id, friend_id: member_id }
     end
-  end
+end
   

--- a/app/models/header.rb
+++ b/app/models/header.rb
@@ -1,0 +1,4 @@
+class Header < ApplicationRecord
+  belongs_to :member
+end
+  

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -3,12 +3,22 @@ class Member < ApplicationRecord
 
     has_many :friendships
     has_many :friends, through: :friendships
+    has_many :headers
+
+    after_create :scrape_headers, :shorten_url
   
     def name
       "#{self.first_name} #{self.last_name}"
     end  
     
     private
+
+    def scrape_headers
+      headers = HeaderScraper.call(self)
+      headers.each do |head|
+        self.headers.create(text: head)
+      end
+    end
 
     def shorten_url
       short_url = UrlShortener.call(self)

--- a/app/poro/header_scraper.rb
+++ b/app/poro/header_scraper.rb
@@ -1,0 +1,22 @@
+require "open-uri"
+
+class HeaderScraper
+
+  def initialize(member)
+    @member = member
+  end
+
+  def self.call(*args)
+    new(*args).scrape_headers
+  end
+
+  def scrape_headers 
+    begin
+      doc = Nokogiri::HTML(URI.open("https://#{@member.original_url}"))
+      headers = doc.css("h1, h2, h3").map { |h| h.text.strip }
+    rescue SocketError, Errno::ECONNREFUSED, Errno::ENOENT => error
+      puts "Error: #{error.message}"
+    end
+    headers
+  end
+end

--- a/app/poro/url_shortener.rb
+++ b/app/poro/url_shortener.rb
@@ -10,8 +10,6 @@ class UrlShortener
     new(*args).shorten_url
   end
   
-  private
-
   def shorten_url
     ShortURL.shorten(@member.original_url, :tinyurl)
   end

--- a/db/migrate/20210331141956_create_headers.rb
+++ b/db/migrate/20210331141956_create_headers.rb
@@ -1,0 +1,9 @@
+class CreateHeaders < ActiveRecord::Migration[6.1]
+  def change
+    create_table :headers do |t|
+      t.timestamps
+      t.references :member, foreign_key: true
+      t.string :text
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_31_135658) do
+ActiveRecord::Schema.define(version: 2021_03_31_141956) do
 
   create_table "friendships", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
@@ -18,6 +18,14 @@ ActiveRecord::Schema.define(version: 2021_03_31_135658) do
     t.integer "member_id", null: false
     t.bigint "friend_id", null: false
     t.index ["member_id"], name: "index_friendships_on_member_id"
+  end
+
+  create_table "headers", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "member_id"
+    t.string "text"
+    t.index ["member_id"], name: "index_headers_on_member_id"
   end
 
   create_table "members", force: :cascade do |t|
@@ -30,4 +38,5 @@ ActiveRecord::Schema.define(version: 2021_03_31_135658) do
   end
 
   add_foreign_key "friendships", "members"
+  add_foreign_key "headers", "members"
 end

--- a/test/models/header_test.rb
+++ b/test/models/header_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class HeaderTest < ActiveSupport::TestCase
+  
+  test "belongs_to member" do
+    header = Header.new
+    assert header.respond_to? :member    
+  end
+
+end

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -30,4 +30,11 @@ class MemberTest < ActiveSupport::TestCase
     assert member.respond_to? :friends
   end
 
+  test "has_many headers" do
+    member_info = {first_name: 'Daniel', last_name: 'Cox', original_url: 'www.apple.com'}
+    member = Member.new(member_info)
+    
+    assert member.respond_to? :headers
+  end
+
 end


### PR DESCRIPTION
WHY:

In order to find and create friendships, members will need to be able
to search for friends based on common interests. The headers
associated with the members url will be the basis for the common interests.

HOW:

Put in header scraper class
Tie in the functionalty